### PR TITLE
fix: :bug: fix portfolio for empty watchlist

### DIFF
--- a/frontend/components/(dashboard)/portfolio/UserTable.tsx
+++ b/frontend/components/(dashboard)/portfolio/UserTable.tsx
@@ -60,7 +60,7 @@ const UserTable = () => {
   const { theme } = useTheme()
   const { profile, user, refetchProfile, openModalConvertUser } = useUser()
   const { isOpen, onOpen, onOpenChange } = useDisclosure()
-  const { getPortfolio, portfolio, loading } = usePortfolio()
+  const { getPortfolio, portfolio, loading, clearPortofolio } = usePortfolio()
   const [shouldRefresh, setShouldRefresh] = useState(false)
   const {
     watchlists,
@@ -83,7 +83,12 @@ const UserTable = () => {
       if (!params.membership) return
       if (!symbols) return
       if (symbols) {
-        if (symbols.watchlist_symbols.length === 0) return
+        toast.dismiss()
+        if (symbols.watchlist_symbols.length === 0) {
+          clearPortofolio()
+          toast.warning('Selected Watchlist is Empty')
+          return
+        }
         params.symbols = symbols.watchlist_symbols
           .map((ticker) => ticker.symbol)
           .join(',')
@@ -224,6 +229,9 @@ const UserTable = () => {
           rowData={portfolio ?? []}
           columnDefs={colDefs}
           defaultColDef={defaultColDef}
+          noRowsOverlayComponent={() => (
+            <div>Watchlist is Empty. Please add Symbols.</div>
+          )}
           loading={loading}
           loadingOverlayComponent={() => <Spinner size="lg" />}
         />

--- a/frontend/components/(dashboard)/portfolio/hooks/usePortfolio.ts
+++ b/frontend/components/(dashboard)/portfolio/hooks/usePortfolio.ts
@@ -37,5 +37,8 @@ export const usePortfolio = create<IPortfolioState & IPortfolioAction>(
         set(() => ({ portfolio: [], loading: false }))
       }
     },
+    clearPortofolio: () => {
+      set(() => ({ portfolio: [], loading: false }))
+    },
   })
 )

--- a/frontend/components/(dashboard)/portfolio/types.d.ts
+++ b/frontend/components/(dashboard)/portfolio/types.d.ts
@@ -42,6 +42,7 @@ export interface IPortfolioState {
 
 export interface IPortfolioAction {
   getPortfolio: (params: IPortfolioParams, refresh?: boolean) => Promise<void>
+  clearPortofolio: () => void
 }
 
 // * WATCHLIST INTERFACE


### PR DESCRIPTION
If a user selects a watchlist that is empty, no API is called and an overlay is shown prompting them to add Symbols to their watchlist and you also get a toast notification. 